### PR TITLE
#12

### DIFF
--- a/include/Candidate.hpp
+++ b/include/Candidate.hpp
@@ -46,6 +46,8 @@
 #include "Rect3.hpp"
 #include "Math.hpp"
 
+#include <boost/math/special_functions/fpclassify.hpp> // isnan
+
 /*! @class Candidate
  *  @brief detection candidate
  *
@@ -170,7 +172,7 @@ public:
 				continue;
 
 			for (cv::MatIterator_<float> it = part.begin(); it != part.end(); ++it) {
-				if (*it != 0 && !std::isnan(*it)) points.push_back(*it);
+				if (*it != 0 && !boost::math::isnan(*it)) points.push_back(*it);
 			}
 
 			if(points.empty())

--- a/include/DynamicProgram.hpp
+++ b/include/DynamicProgram.hpp
@@ -72,6 +72,7 @@ public:
 	virtual ~DynamicProgram() {}
 	// public methods
 	void min(Parts& parts, vector2DMat& scores, vector4DMat& Ix, vector4DMat& Iy, vector4DMat& Ik, vector2DMat& rootv, vector2DMat& rooti);
+	void min_with_backtracking(Parts& parts, vector2DMat& scores, vector4DMat& Ix, vector4DMat& Iy, vector4DMat& Ik, vector2DMat& rootv, vector2DMat& rooti, const vectorf &scales, vectorCandidate &candidates);
 	void argmin(Parts& parts, const vector2DMat& rootv, const vector2DMat& rooti, const vectorf scales, const vector4DMat& Ix, const vector4DMat& Iy, const vector4DMat& Ik, vectorCandidate& candidates);
 	void distanceTransform(const cv::Mat& score_in, const vectorf w, cv::Point os, cv::Mat& score_out, cv::Mat& Ix, cv::Mat& Iy);
 };

--- a/include/Parts.hpp
+++ b/include/Parts.hpp
@@ -171,7 +171,7 @@ public:
 	//! the part's bias
 	vectorf bias(unsigned int mixture = 0) const {
 		const int offset = (*biasid_)[self_][mixture];
-		return vectorf(&((*biasw_)[offset]), &((*biasw_)[offset+nmixtures()]));
+		return vectorf((*biasw_).begin() + offset, (*biasw_).begin() + offset + nmixtures());
 	}
 	//! the part's bias index
 	int biasi(unsigned int mixture = 0) const { return (*biasi_)[(*biasid_)[self_][mixture]]; }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,12 @@ if (cvmatio_FOUND)
 endif()
 
 # as a library (always)
-add_library(${PROJECT_NAME}_lib STATIC ${SRC_FILES})
+if(MSVC)
+    # no symbol exported, so make static library instead
+    add_library(${PROJECT_NAME}_lib STATIC ${SRC_FILES})
+else()
+    add_library(${PROJECT_NAME}_lib SHARED ${SRC_FILES})
+endif()
 target_link_libraries(${PROJECT_NAME}_lib ${LIBS})
 set_target_properties(${PROJECT_NAME}_lib PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 install(TARGETS ${PROJECT_NAME}_lib 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ if (cvmatio_FOUND)
 endif()
 
 # as a library (always)
-add_library(${PROJECT_NAME}_lib SHARED ${SRC_FILES})
+add_library(${PROJECT_NAME}_lib STATIC ${SRC_FILES})
 target_link_libraries(${PROJECT_NAME}_lib ${LIBS})
 set_target_properties(${PROJECT_NAME}_lib PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 install(TARGETS ${PROJECT_NAME}_lib 

--- a/src/PartsBasedDetector.cpp
+++ b/src/PartsBasedDetector.cpp
@@ -84,7 +84,8 @@ void PartsBasedDetector<T>::detect(const Mat& im, const Mat& depth, vectorCandid
 	vector4DMat Ix, Iy, Ik;
 	vector2DMat rootv, rooti;
 	t = (double)getTickCount();
-	dp_.min(parts_, pdf, Ix, Iy, Ik, rootv, rooti);
+	// dp_.min(parts_, pdf, Ix, Iy, Ik, rootv, rooti);
+	dp_.min_with_backtracking(parts_, pdf, Ix, Iy, Ik, rootv, rooti, features_->scales(), candidates);
 	printf("DP min time: %f\n", ((double)getTickCount() - t)/getTickFrequency());
 
 	// suppress non-maximal candidates
@@ -94,7 +95,7 @@ void PartsBasedDetector<T>::detect(const Mat& im, const Mat& depth, vectorCandid
 
 	// walk back down the tree to find the part locations
 	t = (double)getTickCount();
-	dp_.argmin(parts_, rootv, rooti, features_->scales(), Ix, Iy, Ik, candidates);
+	// dp_.argmin(parts_, rootv, rooti, features_->scales(), Ix, Iy, Ik, candidates);
 	printf("DP argmin time: %f\n", ((double)getTickCount() - t)/getTickFrequency());
 
 	if (!depth.empty()) {

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -115,6 +115,7 @@ int main(int argc, char** argv) {
         Mat canvas;
 	if (candidates.size() > 0) {
 	    Candidate::sort(candidates);
+        candidates.resize(1);
 	    //Candidate::nonMaximaSuppression(im, candidates, 0.2);
 	    visualize.candidates(im, candidates, canvas, true);
             visualize.image(canvas);

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -115,7 +115,6 @@ int main(int argc, char** argv) {
         Mat canvas;
 	if (candidates.size() > 0) {
 	    Candidate::sort(candidates);
-        candidates.resize(1);
 	    //Candidate::nonMaximaSuppression(im, candidates, 0.2);
 	    visualize.candidates(im, candidates, canvas, true);
             visualize.image(canvas);


### PR DESCRIPTION
- Make static lib on windows platform, because no symbol exported.
- Use `boost::math::isnan` for portability.
- Change vector construction code to pass assert in vector operator `[]`.
- Move the backtracking part into dp algorithm, to reduce memory use. (Just some adhoc changes. Redundant variables not removed.)
