### PR TITLE
Make reading xml robust to blank values

### DIFF
--- a/src/FileStorageModel.cpp
+++ b/src/FileStorageModel.cpp
@@ -37,7 +37,6 @@
  */
 
 #include <sstream>
-#include <iostream>
 #include <opencv2/core/core.hpp>
 #include "FileStorageModel.hpp"
 


### PR DESCRIPTION
This is related the #4. Older versions of OpenCV do not like blank values in XML. I am on Linux Mint 14, gcc version 4.7.2 (Ubuntu/Linaro 4.7.2-2ubuntu1), OpenCV 2.3.1-11ubuntu2.
