### PR TITLE
Fixed cmake Eigen3 include issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ endif ()
 # DEPENDENCIES
 # -----------------------------------------------
 # find the dependencies
-include(cmake/FindEigen.cmake)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Boost COMPONENTS system filesystem signals REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Eigen REQUIRED)


### PR DESCRIPTION
Adding the cmake directory of the repository to CMAKE_MODULE_PATH was necessary for cmake to find "FindEigen.cmake" module in the subdirectory.
The include statement itself seems to be not sufficient and cmake aborts.
