### PR TITLE
Cast double -> float fixing compile error in OSX

### DIFF
--- a/src/HOGFeatures.cpp
+++ b/src/HOGFeatures.cpp
@@ -113,7 +113,7 @@ void HOGFeatures<T>::pyramid(const Mat& im, vectorMat& pyrafeatures) {
 	#endif
 	for (size_t i = 0; i < interval_; ++i) {
 		Mat scaled;
-		resize(im, scaled, imsize * (1.0f/pow(sfactor_,(int)i)));
+		resize(im, scaled, imsize * (float) (1.0f/pow(sfactor_,(int)i)));
 		pyraimages[i] = scaled;
 		scales_[i] = pow(sfactor_,(int)i)*binsize_;
 		// perform subsequent power of two scaling


### PR DESCRIPTION
I am not sure the reason, but I was having the following compile error in OSX 10.10:

```
/Users/javier/Dev/PartsBasedDetector/src/HOGFeatures.cpp:116:29: error: invalid operands to binary expression ('Size_<float>' and 'double')
                resize(im, scaled, imsize * (1.0f/pow(sfactor_,(int)i)));
```

Clang version:
Apple LLVM version 6.0 (clang-600.0.54) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin14.0.0
Thread model: posix

OpenCV 2.4.9
